### PR TITLE
Add typescript as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/debug": "^4.1.5",
     "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7",
-    "pkg": "^5.1.0"
+    "pkg": "^5.1.0",
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "start": "yarn build && env-cmd node build/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,6 +3651,11 @@ typegram@^3.2.0:
   resolved "https://registry.yarnpkg.com/typegram/-/typegram-3.2.4.tgz#b16310822c23d41a1d552d3fdc974f2d1c231d42"
   integrity sha512-UkWgXIXZYwXK0q6zyZ4xtlETAmmgAt1Y4EFL5Ia87bIort1HHBw+RAMnO7eC1PYogCAKPSCeCSBAZVIoxQ/Dvw==
 
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
 uglify-js@^3.1.4:
   version "3.13.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.5.tgz#5d71d6dbba64cf441f32929b1efce7365bb4f113"


### PR DESCRIPTION
Another minor issue: Typescript is currently not a dependency and compiling using `tsc` will fail on systems where Typescript isn't installed globally.

This PR adds the latest version of `typescript` as a dev dependency, ensuring compilation works on any system out-of-the-box.