### PR TITLE
Add support for Linux and macOS (x64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The app opens a Chrome browser and automatically navigates through the page. It 
 ## Run the application without a development environment
 
 If you just want to run the application head over to the [Releases](https://github.com/marcoklein/impftermin/releases) page and download the latest version.
-Currently the app is compiled for Windows only.
+Currently the app is compiled for Windows, macOS and Linux.
 
 Create a new file called `config.json` next to the executable. This is where you define your locations please read the [Configuration](#configuration) section for setup.
 
@@ -136,7 +136,8 @@ For development
 
 ## Tested on
 
-Windows 10, Node 14
+- Windows 10, Node 14
+- Debian 10, Node 14
 
 # Attribution and legal
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "start": "yarn build && env-cmd node build/index.js",
     "build": "tsc",
     "watch": "nodemon --exec \"yarn start\" --watch src -e ts",
-    "package": "yarn build && pkg -t win-x64 -o dist/impftermin.exe build/index.js --public",
+    "package": "yarn build && pkg -t win-x64 -o dist/impftermin.exe build/index.js --public && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",
+    "package:win": "yarn build && pkg -t win-x64 -o dist/impftermin.exe build/index.js --public",
+    "package:macos": "yarn build && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public",
+    "package:linux": "yarn build && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",
     "release": "env-cmd release-it"
   },
   "hooks": {
@@ -32,7 +35,9 @@
     "github": {
       "release": true,
       "assets": [
-        "dist/*.exe"
+        "dist/*.exe",
+        "dist/impftermin-macos",
+        "dist/impftermin-linux"
       ]
     },
     "npm": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "start": "yarn build && env-cmd node build/index.js",
     "build": "tsc",
     "watch": "nodemon --exec \"yarn start\" --watch src -e ts",
-    "package": "yarn build && pkg -t win-x64 -o dist/impftermin.exe build/index.js --public && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",
-    "package:win": "yarn build && pkg -t win-x64 -o dist/impftermin.exe build/index.js --public",
+    "package": "yarn build && yarn package:win && yarn package:macos && yarn package:linux",
+    "package:win": "yarn build && pkg -t win-x64 -o dist/impftermin-win.exe build/index.js --public",
     "package:macos": "yarn build && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public",
     "package:linux": "yarn build && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",
     "release": "env-cmd release-it"
@@ -35,7 +35,7 @@
     "github": {
       "release": true,
       "assets": [
-        "dist/*.exe",
+        "dist/impftermin-win.exe",
         "dist/impftermin-macos",
         "dist/impftermin-linux"
       ]


### PR DESCRIPTION
I tested the compiled binary on Linux (Debian 10) and it works well.

I couldn't test the binary on macOS, but given the maturity of `pkg` and the other dependencies, the tool should work fine on macOS too.