### PR TITLE
fix: release-it hook is now called

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "package:win": "yarn build && pkg -t win-x64 -o dist/impftermin-win.exe build/index.js --public",
     "package:macos": "yarn build && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public",
     "package:linux": "yarn build && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",
-    "release": "env-cmd release-it"
-  },
-  "hooks": {
-    "after:bump": "yarn package"
+    "release": "env-cmd release-it --verbose"
   },
   "release-it": {
     "github": {
@@ -39,6 +36,9 @@
         "dist/impftermin-macos",
         "dist/impftermin-linux"
       ]
+    },
+    "hooks": {
+      "after:bump": "yarn package"
     },
     "npm": {
       "publish": false


### PR DESCRIPTION
The hook configuration is now under release-it so it runs automatically on a release.