### PR TITLE
fix add leading zero when minute is lower than 10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ debug("Launching Impftermin");
       date.getTime() + configuration.intervalInMinutes * 60000
     );
 
-    return `${nextDate.getHours()}:${nextDate.getMinutes()}`;
+    return `${nextDate.getHours()}:${(nextDate.getMinutes()<10?'0':'') + nextDate.getMinutes()}`;
   };
 
   const runChecks = async () => {


### PR DESCRIPTION
Noticed that if minutes are below 10 there is no leading zero.
![image](https://user-images.githubusercontent.com/5982615/117352943-de7a5100-aeaf-11eb-9a99-5d8fe1b57ed7.png)

With this pull request there is a leading zero. Think this matches the expected time format.
![image](https://user-images.githubusercontent.com/5982615/117353122-08337800-aeb0-11eb-9501-b0d4957e076a.png)
