### PR TITLE
Remove unnecessary build step before packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "yarn build && env-cmd --silent node build/index.js",
     "build": "tsc",
     "watch": "nodemon --exec \"yarn start\" --watch src -e ts",
-    "package": "yarn build && yarn package:win && yarn package:macos && yarn package:linux",
+    "package": "yarn package:win && yarn package:macos && yarn package:linux",
     "package:win": "yarn build && pkg -t win-x64 -o dist/impftermin-win.exe build/index.js --public",
     "package:macos": "yarn build && pkg -t macos-x64 -o dist/impftermin-macos build/index.js --public",
     "package:linux": "yarn build && pkg -t linux-x64 -o dist/impftermin-linux build/index.js --public",


### PR DESCRIPTION
Removes unnecessary `ỳarn build` call in `yarn package` entry.

See #4.