### PR TITLE
Bugfix for Invalid configuration: StructError: At path: queue.0.url -…

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,7 @@ export interface Config {
   queue: {
     url: string;
     code?: string;
+    
   }[];
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,7 +25,7 @@ export interface Config {
 
 const urlValidator = (url: any) => {
   url = String(url);
-  return isUrl(url) && new URL(url).host == "impfterminservice.de";
+  return isUrl(url) && new URL(url).host.match("[^.]+\\.impfterminservice\\.de")!=null;
 };
 
 const Url = define("ImpfterminURL", urlValidator);


### PR DESCRIPTION
…- Expected a value of type `ImpfterminURL