### PR TITLE
Addapt logic for appointments

### DIFF
--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -114,12 +114,14 @@ async function proceedWithACode(page: Page, impfCode: string) {
   }
 
   if (
-    !appointmentWarning ||
-    !appointmentText ||
-    !appointmentText.includes("stehen leider keine Termine zur")
+    !appointmentWarning &&
+    appointmentText && (
+    !appointmentText.includes("stehen leider keine Termine zur") &&
+    !appointmentText.includes("Termine werden gesucht"))
   ) {
     // appointments available!!!
     debug("Appointments available!!");
+    debug(appointmentText);
     return true;
   }
   debug("No appointments");


### PR DESCRIPTION
If the system is slow the screen "Termine werden gesucht"
will stay for a long time. This is currently detected as
valid appointment.

Adapt the logic which used OR instead of AND.
Please note that I didn't had any successful hit so far.

Closes #30