### PR TITLE
Adapt logic for appointments

### DIFF
--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -114,15 +114,19 @@ async function proceedWithACode(page: Page, impfCode: string) {
   }
 
   if (
-    !appointmentWarning ||
+    !appointmentWarning &&
     !appointmentText ||
-    !appointmentText.includes("stehen leider keine Termine zur")
+    appointmentText && (
+    !appointmentText.includes("stehen leider keine Termine zur") &&
+    !appointmentText.includes("Termine werden gesucht"))
   ) {
     // appointments available!!!
     debug("Appointments available!!");
+    debug(appointmentText);
     return true;
   }
   debug("No appointments");
+  debug(appointmentText);
   return false;
 }
 


### PR DESCRIPTION
If the system is slow the screen "Termine werden gesucht"
will stay for a long time. This is currently detected as
valid appointment.

Adapt the logic which used OR instead of AND.
Please note that I didn't had any successful hit so far.

Closes #30