### PR TITLE
Solution to issue #30 if appointments screen does not appear at all, which still gives false positives

### DIFF
--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -121,8 +121,9 @@ async function proceedWithACode(page: Page, impfCode: string) {
   // ) 
   
   
-  // it is better to determine the offer availability by actually checking that there is an offer shown, since from time to time there is no
-  // no window (with our without available dates) shown at all  after hitting the search appointment button. In this case, the previous if gives a // false positive. When there is a real appointment shown, it always gives dates with a time. Therefore checking for "Uhr" seems failsafe
+  // it is better to determine the appointment availability by actually checking that there is an appointment shown, since from time to time there // is no window (with or without available dates) shown at all  after hitting the search appointment button. In this case, the previous "if" 
+  // gives a false positive. When there is a real appointment shown, it always gives dates with a time. Therefore checking for presence of string
+  //  "Uhr" seems failsafe, since it does not appear on the 'stuck' search for appointments page
   
   for (const listElementRealOffer of await page.$$("span")) {
     const elementText = await (

--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -112,21 +112,12 @@ async function proceedWithACode(page: Page, impfCode: string) {
     debug("We are offline or on some different page");
     return false;
   }
-
-  // if (
-    // (!appointmentWarning && !appointmentText) ||
-    // (appointmentText &&
-      // !appointmentText.includes("stehen leider keine Termine zur") &&
-      // !appointmentText.includes("Termine werden gesucht"))
-  // ) 
-  
-  
-
-  // it is better to determine the appointment availability by actually checking that there is an appointment shown, since from time to time there // is no window (with or without available dates) shown at all  after hitting the search appointment button. In this case, the previous "if" 
+ 
+  // it is better to determine the appointment availability by actually checking that there is an appointment shown, since from time to time there 
+  // is no window (with or without available dates) shown at all after hitting the search appointment button. In this case, the previous "if" 
   // gives a false positive. When there is a real appointment shown, it always gives dates with a time. Therefore checking for presence of string
   //  "Uhr" seems failsafe, since it does not appear on the 'stuck' search for appointments page
-
-  
+	
   for (const listElementRealOffer of await page.$$("span")) {
     const elementText = await (
 		await listElementRealOffer.getProperty("innerText")

--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -113,16 +113,28 @@ async function proceedWithACode(page: Page, impfCode: string) {
     return false;
   }
 
-  if (
-    (!appointmentWarning && !appointmentText) ||
-    (appointmentText &&
-      !appointmentText.includes("stehen leider keine Termine zur") &&
-      !appointmentText.includes("Termine werden gesucht"))
-  ) {
-    // appointments available!!!
-    debug("Appointments available!!");
-    debug("DEBUG: appointmentText=%s", appointmentText);
-    return true;
+  // if (
+    // (!appointmentWarning && !appointmentText) ||
+    // (appointmentText &&
+      // !appointmentText.includes("stehen leider keine Termine zur") &&
+      // !appointmentText.includes("Termine werden gesucht"))
+  // ) 
+  
+  
+  // it is better to determine the offer availability by actually checking that there is an offer shown, since from time to time there is no
+  // no window (with our without available dates) shown at all  after hitting the search appointment button. In this case, the previous if gives a // false positive. When there is a real appointment shown, it always gives dates with a time. Therefore checking for "Uhr" seems failsafe
+  
+  for (const listElementRealOffer of await page.$$("span")) {
+    const elementText = await (
+		await listElementRealOffer.getProperty("innerText")
+	)?.jsonValue<string>();
+	if (elementText && elementText.includes("Uhr"))   
+	{
+		// appointments available!!!
+		debug("Appointments available!!");
+		debug("DEBUG: appointmentText=%s", appointmentText);
+		return true;
+	}
   }
   debug("No appointments");
   debug("DEBUG: appointmentText=%s", appointmentText);


### PR DESCRIPTION
Issue #30 is imho still not solved in the case that the appointments screen does not open at all. I don't know the reason for this behavior, but it happens from time to time that the screen simply does not open even after very long waiting time. I have a proposal how to solve this by evaluating the positive condition that a real appointment is actually presented and visible. I changed the criterion for available appointments detection in appointments.ts:proceedWithACode(). Now detection is done by checking if there is a real appointment date shown, and therefore should not lead to false positives anymore. 