### PR TITLE
autobooking token added to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.log
 config.json
 dist
+config - StandardTest.json

--- a/src/booking.ts
+++ b/src/booking.ts
@@ -3,6 +3,7 @@ import Debug from "debug";
 import { QueueElement } from "./configuration";
 const debug = Debug("impftermin:booking");
 import { coloredError } from "./index";
+import { enableAutobooking } from "./index";
 
 export async function bookAppointment(page: Page, queueEntry: QueueElement) {
   // Check that all personal data is available
@@ -174,7 +175,17 @@ export async function bookAppointment(page: Page, queueEntry: QueueElement) {
   // Final confirmation, BINDING booking!!!
   const bookingButton = await page.$("button.search-filter-button");
   // for debugging, the following button click must be deactivated!!! otherwise a binding appointment will be booked!!!
-  await bookingButton?.click({ delay: 500 });
+  if (enableAutobooking){
+	  await bookingButton?.click({ delay: 500 });
+	  debug("Autobooking token true");
+  }else{
+	  debug(" ");
+	  debug("=================================================");
+	  debug("Autobooking token false / not set, NOTHING BOOKED");
+	  debug("    Appointment booking is only SIMULATED!!!");
+	  debug("=================================================");
+	  debug(" ");
+  }
 
   debug(" ");
   debug("===========================================");

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,6 +33,7 @@ export interface Config {
     earliestdate?: string;
     latestdate?: string;
   }[];
+  enableAutobooking?: string;
 }
 
 export interface QueueElement {
@@ -82,6 +83,7 @@ const Config = object({
       latestdate: optional(string()),
     })
   ),
+  enableAutobooking: optional(string()),
 });
 
 const configPaths = [path.join("config.json"), path.join("../config.json")];

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "os";
 import * as path from "path";
 const debug = Debug("impftermin:main");
 import { bgRedBright, whiteBright } from "chalk";
+export var enableAutobooking = false;
 
 export const coloredError = (...text: unknown[]) =>
   bgRedBright(whiteBright(...text));
@@ -19,6 +20,18 @@ debug("Launching Impftermin");
 
 (async () => {
   const configuration = await loadConfiguration();
+  if (configuration.enableAutobooking == "true") {
+	enableAutobooking = true;
+  }else{
+	  enableAutobooking = false;
+	  debug(" ");
+	  debug("=============================================");
+	  debug("=============================================");
+      debug("= ATTENTION! Booking will only be simulated =");
+      debug("=============================================");
+      debug("=============================================");
+      debug(" ");
+  }
 
   const tmpPath = tmpdir();
   const chromePath = path.resolve(path.join(tmpPath, ".local-chromium"));


### PR DESCRIPTION
Added configuration token to explicitly enable autobooking. Without this, the actual booking always has to be manually commented for debugging purposes in order not to book an appointment accidentally